### PR TITLE
Adding Google hangouts to dark sites

### DIFF
--- a/src/config/dark_sites.json
+++ b/src/config/dark_sites.json
@@ -19,5 +19,7 @@
     "shutov.by",
     "spotify.com",
     "store.steampowered.com",
-    "vinesauce.com"
+    "vinesauce.com",
+    "hangouts.google.com",
+    "plus.google.com/hangouts"
 ]


### PR DESCRIPTION
Google hangouts also should be marked dark because many of the images
are background images, which get reversed