### PR TITLE
Added https://spacespacespaaace.space

### DIFF
--- a/src/config/dark_sites.json
+++ b/src/config/dark_sites.json
@@ -28,6 +28,7 @@
     "realgamernewz.com",
     "regexr.com",
     "shutov.by",
+    "spacespacespaaace.space",
     "spotify.com",
     "steamcommunity.com",
     "store.steampowered.com",


### PR DESCRIPTION
Added https://spacespacespaaace.space, a Site honoring Portal 2 and the Space Core.