### PR TITLE
Fix text color in reply composer at inbox.google.com

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -76,7 +76,8 @@
             ],
             "rules": [
                 ".pI { background: rgba(255,255,255,.7) !important; }",
-                ".eB { background: rgba(255,255,255,.4) !important; }"
+                ".eB { background: rgba(255,255,255,.4) !important; }",
+                ".aR { color: rgba(255,255,255,.7) !important; }"
             ]
         },
         {


### PR DESCRIPTION
Both the inline reply and reply sub windows are black text on black backgrounds