### PR TITLE
youtube subscription email preview images get inverted in gmail

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -68,7 +68,7 @@
                 "google.*.*"
             ],
             "invert": [
-                ".gbii, .gbip, .azp, .aLF-aPX-KP, .irc_bg, .RY3tic, canvas.circle"
+                "table[background], .gbii, .gbip, .azp, .aLF-aPX-KP, .irc_bg, .RY3tic, canvas.circle"
             ],
             "noinvert": [
                 ".irc_mi, .irc_rii, .irc_mut, .amI, .amJ, .adk, .adj, [src*='ic_'], [src*='black']",

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -6,12 +6,14 @@
             "svg image",
             "[style*='background:url'], [style*='background-image:url']",
             "[style*='background: url'], [style*='background-image: url']",
+            "[background]",
             "twitterwidget"
         ],
         "noinvert": [
             "[style*='background:url'] *, [style*='background-image:url'] *",
             "[style*='background: url'] *, [style*='background-image: url'] *",
-            "input"
+            "input",
+            "[background] *"
         ],
         "removebg": [],
         "rules": [
@@ -68,7 +70,7 @@
                 "google.*.*"
             ],
             "invert": [
-                "table[background], .gbii, .gbip, .azp, .aLF-aPX-KP, .irc_bg, .RY3tic, canvas.circle"
+                ".gbii, .gbip, .azp, .aLF-aPX-KP, .irc_bg, .RY3tic, canvas.circle"
             ],
             "noinvert": [
                 ".irc_mi, .irc_rii, .irc_mut, .amI, .amJ, .adk, .adj, [src*='ic_'], [src*='black']",


### PR DESCRIPTION
fix youtube subscription emails incorrectly being inverted.
inverts table[background] the table[background] inversion must be before all the other inversions else it breaks the profile icon.