### PR TITLE
atlassian.net confluence: darken editor

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -29,6 +29,12 @@
             "noinvert": "#footer *, #photo-modal *"
         },
         {
+            "url": "atlassian.net",
+            "invert": [
+                ".EditPage_withPanels_3Hr, #toolbar, #savebar-container"
+            ]
+        },
+        {
             "url": "basho.com",
             "invert": [
                 "#site-navigation, footer, header, .featured-news-wrapper",


### PR DESCRIPTION
This change darkens the three components of the edit screen in Atlassian hosted (on atlassian.net) Confluence. I believe due to the loading of this screen's components via ajax, it's not darkened by default.

ps - I totally hand edited this in github UI, hopefully I didn't jack up the line endings.