### PR TITLE
Stopped invertion of the blue parts of the facebook header + profile pic

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -63,7 +63,12 @@
             "invert": [
                 "._3ixn, ._2teu, .uiStreamStory",
                 ".userContentWrapper canvas, ._4lqu, ._4lqt",
-                "._24ws, ._1z0-"
+                "._24ws, ._1z0-",
+                "._2s1x ._2s1y",
+                ".__tw",
+                "#js_9 > div > div > div._2t-e > div:nth-child(1) > h1 > a",
+                "#js_3lc",
+                "#u_0_a > div:nth-child(1) > div:nth-child(1) > div > a > span"
             ],
             "noinvert": ".uiStreamStory video",
             "removebg": "._4d3w .stageWrapper"


### PR DESCRIPTION
Couldn't figure out how to invert the part with the profile pic without inverting the name, so the name is still inverted.
First time doing this, so I may have specified some selectors wrong (I'm especially worried about the two long selectors I added), or put it the wrong place. 

I wanted to stop inverting dark-blue areas as the inverted color doesn't mix well with a dark background (The original color fits slightly more), but couldn't figure out how to do so for the main page elements without specifying the "#js_[somestring]" for each post