### PR TITLE
Fix images on mathpages.com

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -146,6 +146,10 @@
             "removebg": ".ComposeContent"
         },
         {
+            "url": "mathpages.com",
+            "noinvert": "img"
+        },
+        {
             "url": "medium.com",
             "noinvert": ".canvas-renderer"
         },


### PR DESCRIPTION
Most of the images on these pages are dark with a transparent background, making them impossible to read.