### PR TITLE
fix "#discourse-comments" rule

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -1,6 +1,7 @@
 {
     "common": {
         "invert": [
+            "#discourse-comments",
             "img, video, :not(object):not(body)>embed, object",
             "iframe",
             "svg image",


### PR DESCRIPTION
for pages like https://babeljs.io/docs/usage/polyfill/ element "#discourse-comments" should be inverted.