### PR TITLE
Add initial url section for ruby.sketchup.com and rubydoc.info

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -337,6 +337,19 @@
             "invert": "#header-img"
         },
         {
+            "url": [
+                "ruby.sketchup.com",
+                "rubydoc.info"
+            ],
+            "invert": [
+                "header#navbar"
+            ],
+            "noinvert": [
+                "header#navbar a > img",
+                "iframe#nav"
+            ]
+        },
+        {
             "url": "semlar.com",
             "invert": ".thumbnail, .col-sm-2, .img-rounded, #alert-list, .background-texture",
             "noinvert": "img"

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -342,11 +342,11 @@
                 "rubydoc.info"
             ],
             "invert": [
-                "header#navbar"
+                "#navbar"
             ],
             "noinvert": [
-                "header#navbar a > img",
-                "iframe#nav"
+                "#navbar a > img",
+                "#nav"
             ]
         },
         {


### PR DESCRIPTION
This is a inversion fix section for sites that are generated by the YARD Ruby documentation generator.
Most Ruby language Gems have their source on GitHub and documentation on www.RubyDoc.info/gems.
Many other Ruby projects that are also on GitHub have documentation generated (automatically by GitHub) and published to www.RubyDoc.info/github.
Trimble SketchUp (formerly Google SketchUp,) uses YARD to publish their Ruby APIs on their own server.
(The "header#navbar" selector is unique to SketchUp's YARD template, but the standard template does not have this body child element so no harm for RubyDoc.info hosted pages.)
-
This file change only does a few glaring fixes such as inverting the left nav iframe, and reverting the header bar.
There are some other things that need fixing inside the iframe#nav, but I do not know yet how to fix these.
-
* References for YARD :
https://yardoc.org/ 
http://www.rubydoc.info/gems/yard/file/README.md