### PR TITLE
Fix TeX on betterexplained.com

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -50,6 +50,10 @@
             ]
         },
         {
+            "url": "betterexplained.com",
+            "noinvert": "img.tex"
+        },
+        {
             "url": [
                 "bit-tech.net",
                 "forums.bit-tech.net"


### PR DESCRIPTION
The TeX formulae on betterexplained.com have transparent backgrounds, making them impossible to read.