### PR TITLE
Update fix_inversion.json for khan academy

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -183,7 +183,7 @@
                 ".instructionsContainer",
                 "#liveOutput"
             ]
-        },  
+        },
         {
             "url": "ign.com",
             "invert": ".video_embed_content-poster, .video_embed_content-poster-play-button",

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -202,7 +202,7 @@
             "invert": [
                 ".task-container .modal-backdrop"
             ]
-        },          
+        },
         {
             "url": "lifehacker.com",
             "invert": ".videoCube a .thumbBlock",

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -183,14 +183,7 @@
                 ".instructionsContainer",
                 "#liveOutput"
             ]
-        },
-        {
-            "url": "khanacademy.org",
-            "invert": [
-                ".task-container",
-                ".modal-backdrop"
-            ]
-        },    
+        },  
         {
             "url": "ign.com",
             "invert": ".video_embed_content-poster, .video_embed_content-poster-play-button",
@@ -204,6 +197,12 @@
             "url": "io9.com",
             "rules": "html { height: auto !important; }"
         },
+        {
+            "url": "khanacademy.org",
+            "invert": [
+                ".task-container .modal-backdrop"
+            ]
+        },          
         {
             "url": "lifehacker.com",
             "invert": ".videoCube a .thumbBlock",

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -185,6 +185,13 @@
             ]
         },
         {
+            "url": "khanacademy.org",
+            "invert": [
+                ".task-container",
+                ".modal-backdrop"
+            ]
+        },    
+        {
             "url": "ign.com",
             "invert": ".video_embed_content-poster, .video_embed_content-poster-play-button",
             "removebg": "#review-promo"


### PR DESCRIPTION
Proposed change allows full content reading while preserving dark mode. Before, Khan academy unusable with dark reader because white needed for showing graphs.

Without edits
https://drive.google.com/drive/folders/1CY3zY1IA5q-d2w6EyLDz6Z54XUINu_DR
With edits
https://drive.google.com/drive/folders/1CY3zY1IA5q-d2w6EyLDz6Z54XUINu_DR