### PR TITLE
Github header fix

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -151,7 +151,8 @@
                 ".bg-gray-light",
                 ".bg-gray-dark",
                 ".bg-gray-light .btn-block",
-                ".bg-gray-dark .form-group"
+                ".bg-gray-dark .form-group",
+                ".Header"
             ]
         },
         {


### PR DESCRIPTION
Added Github .Header element into invert list so that it inverts once more and becomes dark