### PR TITLE
Fix images on libretexts.org

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -204,6 +204,10 @@
             ]
         },
         {
+            "url": "libretexts.org",
+            "noinvert": "img"
+        },
+        {
             "url": "lifehacker.com",
             "invert": ".videoCube a .thumbBlock",
             "rules": "html { height: auto !important; }"


### PR DESCRIPTION
Most of the images on this site are diagrammatic (graphs, formulae, molecular structures, etc.) and I'm having a much easier time with the inverted versions. There may be a more clever way to do this, but I think it's a decent first approximation.