### PR TITLE
Fix images on feynmanlectures.caltech.edu

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -141,6 +141,10 @@
             "rules": "._2s1x ._2s1y { background: #9BB5E8 !important; color: black !important; border-bottom-color: #92A6CA !important; }"
         },
         {
+            "url": "feynmanlectures.caltech.edu",
+            "noinvert": "img"
+        },
+        {
             "url": "gigaom.com",
             "invert": ".bg"
         },


### PR DESCRIPTION
The images here are also mostly diagrammatic and mostly unreadable without inversion.