### PR TITLE
partial fix for reading livescience.com bacground

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -226,6 +226,12 @@
             ]
         },
         {
+            "url": "livescience.com",
+            "invert": [
+                "background-color"
+            ]
+        },
+        {
             "url": "mail.live.com",
             "invert": [
                 "img:not([src='https://a.gfx.ms/rte_metro2.png'])",


### PR DESCRIPTION
still not whole page inverted but at least it is now readable.