### PR TITLE
Fix Google Docs color palettes

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -93,6 +93,10 @@
             ]
         },
         {
+            "url": "docs.google.com/document/*",
+            "invert": ".jfk-palette-colorswatch"
+        },
+        {
             "url": "docs.microsoft.com",
             "invert": ".theme-dark"
         },

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -93,7 +93,7 @@
             ]
         },
         {
-            "url": "docs.google.com/document/*",
+            "url": "docs.google.com",
             "invert": ".jfk-palette-colorswatch"
         },
         {


### PR DESCRIPTION
With this change, color palettes on Google Docs document viewer will correctly display their specified color.