### PR TITLE
Fix math equations on wikipedia.org

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -547,7 +547,10 @@
         {
             "url": "wikipedia.org",
             "invert": ".mwe-popups-discreet > svg",
-            "noinvert": ".mwe-math-fallback-image-inline"
+            "noinvert": [
+              ".mwe-math-fallback-image-inline",
+              ".mwe-math-fallback-image-display"
+            ]
         },
         {
             "url": "wikiwand.com",

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -548,8 +548,8 @@
             "url": "wikipedia.org",
             "invert": ".mwe-popups-discreet > svg",
             "noinvert": [
-              ".mwe-math-fallback-image-inline",
-              ".mwe-math-fallback-image-display"
+                ".mwe-math-fallback-image-inline",
+                ".mwe-math-fallback-image-display"
             ]
         },
         {


### PR DESCRIPTION
Ran across some math using the `mwe-math-fallback-image-display` class. This makes it possible to read on a dark background.