### PR TITLE
Fixed Google Apps and Search by Voice icons

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -176,7 +176,7 @@
                 "google.*.*"
             ],
             "invert": [
-                ".gbii, .gbip, .azp, .aLF-aPX-KP, .irc_bg, .RY3tic, canvas.circle"
+                ".gb_2, .gb_M, .gsri_a, .gbii, .gbip, .azp, .aLF-aPX-KP, .irc_bg, .RY3tic, canvas.circle"
             ],
             "noinvert": [
                 ".irc_mi, .irc_rii, .irc_mut, .act-icon-dark-gray, .amI, .amJ, .adk, .adj, [src*='ic_'], [src*='black']",


### PR DESCRIPTION
Added '.gb_2, .gb_M, .gsri_a' to google invert list (line 179). The first two inversions restore the google apps icons to their' original colors. The last one will restore the search by voice icon to its original color.