### PR TITLE
Add electronics-tutorials.ws support

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -116,6 +116,10 @@
             ],
             "noinvert": "body[style*='background-image: url']"
         },
+        { 
+            "url": "electronics-tutorials.ws",
+            "removebg": "img"
+        },
         {
             "url": "evernote.com",
             "noinvert": [

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -116,7 +116,7 @@
             ],
             "noinvert": "body[style*='background-image: url']"
         },
-        { 
+        {
             "url": "electronics-tutorials.ws",
             "removebg": "img"
         },


### PR DESCRIPTION
"removebg": "img" because Gif are transparents and look is bad.