### PR TITLE
Update fix_inversion.json for Sharepoint/Onenote

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -429,6 +429,10 @@
             "noinvert": "img"
         },
         {
+            "url": "sharepoint.com",
+            "noinvert": "iframe"
+        },
+        {
             "url": "shop.ubi.com",
             "invert": "#topNavbar, #UplayHeader"
         },


### PR DESCRIPTION
On the corporate version of Office365 (sharepoint.com), OneNote is not inverted. It seems this happens because the entire page is pretty much an iframe, so there are 2 nested HTML elements which cancel each other.