### PR TITLE
Add "minhaclaro" site

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -338,6 +338,10 @@
             "invert": "._4tsk"
         },
         {
+            "url": "minhaclaro.claro.com.br",
+            "invert": ".header-black, .header-red-desktop-logada"
+        },
+        {
             "url": "mp.weixin.qq.com/wiki",
             "noinvert": [
                 ".res_iframe"


### PR DESCRIPTION
minhaclaro is the site that claro customers use to check their mobile plan.
It already has some dark elements, but not all of it.These were being inverted into white colors or washed up red. add them to exclusion so all the site is black with the right tone of red