### PR TITLE
Update fix_inversion.json for immutables.github.io

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -243,6 +243,10 @@
             "invert": "#nb20, .vital, .poster, .slate, .slate_fade_top, .slate_fade_bottom"
         },
         {
+            "url": "immutables.github.io",
+            "invert": ".illustration, .documentation .highlight"
+        },
+        {
             "url": "io9.com",
             "rules": "html { height: auto !important; }"
         },


### PR DESCRIPTION
https://immutables.github.io/ and https://immutables.github.io/immutable.html are some documentation pages I reference a lot.

In dark mode, all the code samples become white. This fixes that.

Original CSS style being overridden:
```css
.illustration, .documentation .highlight {
...
    background-color: #2B303B;
...
}
```