### PR TITLE
Add support for gitlab.com

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -204,6 +204,19 @@
             ]
         },
         {
+            "url": "gitlab.com",
+            "invert": [
+                ".navbar",
+                ".code.dark, .code.dark .notes_holder",
+                ".code.solarized-dark, .code.solarized-dark .notes_holder",
+                ".code.monokai, .code.monokai .notes_holder",
+                "#build-trace"
+            ],
+            "noinvert": [
+                ".ui_light .navbar"
+            ]
+        },
+        {
             "url": [
                 "google.*",
                 "google.*.*"


### PR DESCRIPTION
*  `.navbar` invert changes the navbar back as most themes have a dark navbar.
    *  Skip the `.ui_light` theme with `noinvert` as that one has the light navbar.
*  Re-invert the 3 code diff themes that are already dark.
*  Invert the build trace for pipelines as that is dark already