### PR TITLE
Add 2 Custom speedtests for Local ISP

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -655,6 +655,14 @@
             ]
         },
         {
+            "url": "velocimetro.virtua.com.br",
+            "invert": "body"
+        },
+        {
+            "url": "virtua.speedtestcustom.com",
+            "noinvert": "img"
+        },
+        {
             "url": "vk.com",
             "invert": [
                 "#video_player, .mv_playlist, .page_header_cont, .page_album_title",

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -656,11 +656,11 @@
         },
         {
             "url": "velocimetro.virtua.com.br",
-            "invert": "body"
+            "noinvert": "iframe"
         },
         {
             "url": "virtua.speedtestcustom.com",
-            "noinvert": "img"
+            "noinvert": ".branding"
         },
         {
             "url": "vk.com",


### PR DESCRIPTION
"virtua.speedtestcustom.com" is inverted except for its logo (which is being inverted to white).
"velocimetro.virtua.com.br" is not inverted at all, even though the site itself is already white