### PR TITLE
Fix LaTeX images on terrytao.wordpress.com

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -612,6 +612,10 @@
             "rules": "#hlogo a { text-indent: -256em !important; }"
         },
         {
+            "url": "terrytao.wordpress.com",
+            "noinvert": "img.latex"
+        },
+        {
             "url": "tpondemand.com",
             "invert": [
                 ".tau-cover-view__overlay, .tau-app-secondary-pane, .app-header, .uv-popover-content"


### PR DESCRIPTION
The equations on this site are rendered as black symbols on a white background. Inverting these images makes the equations much easier to read.