### PR TITLE
Fix images on terrytao.wordpress.com

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -612,6 +612,10 @@
             "rules": "#hlogo a { text-indent: -256em !important; }"
         },
         {
+            "url": "terrytao.wordpress.com",
+            "noinvert": "img"
+        },
+        {
             "url": "tpondemand.com",
             "invert": [
                 ".tau-cover-view__overlay, .tau-app-secondary-pane, .app-header, .uv-popover-content"


### PR DESCRIPTION
This replaces #248. In addition to the equations, there are a lot of graphs and diagrams with transparent backgrounds that become unreadable.