### PR TITLE
Fix inline equations on wolfram.com

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -825,7 +825,7 @@
         {
             "url": "wolfram.com",
             "noinvert": [
-                ".numberedequation, .displayformula"
+                ".numberedequation, .displayformula, .inlineformula"
             ]
         },
         {


### PR DESCRIPTION
Equations displayed inline have a class of ".inlineformula" -- they should be included as well.