### PR TITLE
Fix headings on BART timetable

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -46,6 +46,10 @@
             ]
         },
         {
+            "url": "bart.gov/schedules",
+            "noinvert": "img"
+        },
+        {
             "url": "basho.com",
             "invert": [
                 "#site-navigation, footer, header, .featured-news-wrapper",


### PR DESCRIPTION
Bay Area Rapid Transit (BART) posts its timetable using images as headers, making the station names unreadable on a dark background.