### PR TITLE
Fix inversion for deezer.com sidebar

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -105,7 +105,7 @@
             "url": "deezer.com",
             "invert": ".page-sidebar",
             "noinvert": ".player-cover *"
-		},
+        },
         {
             "url": "developer.mozilla.org",
             "invert": [

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -102,6 +102,11 @@
             "invert": ".wwzing"
         },
         {
+            "url": "deezer.com",
+            "invert": ".page-sidebar",
+            "noinvert": ".player-cover *"
+		},
+        {
             "url": "developer.mozilla.org",
             "invert": [
                 "#nav-footer, .highlight-span, .readOnlyInline, #nav-sec, #toc",


### PR DESCRIPTION
The deezer.com sidebar was appearing white since it's black by default, this fixes it.