### PR TITLE
Update fix_inversion.json to fix white background in Google Hangouts …

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -15,9 +15,6 @@
             "input",
             "[background] *"
         ],
-        "removebg": [
-            "iframe:not([title='Disqus']):not([src*='ihlenndgcmojhcghmfjfneahoeklbjjh'])"
-        ],
         "rules": [
             "#disqus_thread > :first-child { background: black !important; }"
         ]


### PR DESCRIPTION
…sidebar in Gmail

When logged into gmail the google hangouts sidebar widget is loaded from an iframe that renders with a white background because of line 19.  I'm not sure what downstream impacts removing this line will have so do with as you will.