### PR TITLE
Fix images on mathworld.wolfram.com

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -446,6 +446,10 @@
             ]
         },
         {
+            "url": "mathworld.wolfram.com",
+            "noinvert": "img"
+        },
+        {
             "url": "medium.com",
             "noinvert": ".canvas-renderer"
         },


### PR DESCRIPTION
The images on mathworld.wolfram.com tend to be graphs, diagrams, etc. Inverting the images is a good first order approximation.