### PR TITLE
Improvements for gitlab

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -417,9 +417,10 @@ header,
 
 ================================
 
-gitlab.com
+gitlab.*
 
 INVERT
+gl-emoji
 .navbar
 .code.dark
 .code.dark .notes_holder


### PR DESCRIPTION
Changed gitlab.com to gitlab.* to apply the fixes to self-hosted gitlab instances
un-inverted emojis