### PR TITLE
Fix images on reference.wolfram.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1158,6 +1158,13 @@ INVERT
 
 ================================
 
+reference.wolfram.com
+
+NO INVERT
+img
+
+================================
+
 ruby.sketchup.com
 rubydoc.info
 


### PR DESCRIPTION
Most of the images on this site are formulas, graphs, etc. making them unreadable against the dark background.