### PR TITLE
Update inversion-fixes.config (facebook.com chat fix)

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -321,6 +321,8 @@ INVERT
 ._24ws
 ._1z0-
 ._19eb
+._5rpb
+._5rpu
 
 NO INVERT
 .uiStreamStory video


### PR DESCRIPTION
Do not invert the text inside the chat edit box in the facebook.com website.