### PR TITLE
Update inversion-fixes.config for codebasehq.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -158,6 +158,13 @@ NO INVERT
 
 ================================
 
+codebasehq.com
+
+INVERT
+a.Project__link
+
+================================
+
 dailymail.co.uk
 
 NO INVERT


### PR DESCRIPTION
Invert project links (`a.Project__link`) for codebasehq.com which were black before this.